### PR TITLE
feat: myopia

### DIFF
--- a/src/ColosseumApp.tsx
+++ b/src/ColosseumApp.tsx
@@ -104,7 +104,7 @@ function createTrainer() {
 
 type AttackSetting = Exclude<
   keyof ColosseumSettingsState,
-  "forceDoubleSouth" | "npcsAggressive" | "waveNumber" | "showSolarFlareTiles" | "solarFlareLevel"
+  "forceDoubleSouth" | "myopiaLevel" | "npcsAggressive" | "waveNumber" | "showSolarFlareTiles" | "solarFlareLevel"
 >;
 
 function AttackCheckbox({ label, setting }: { label: string; setting: AttackSetting }) {
@@ -249,6 +249,18 @@ function BossSidebar({ region }: { region: ColosseumRegion }) {
         />
         Solar Flare Tiles
       </label>
+
+      <p>Myopia:</p>
+      <select
+        aria-label="Myopia"
+        value={settings.myopiaLevel}
+        onChange={(event) => colosseumSettings.set({ myopiaLevel: Number(event.currentTarget.value) })}
+      >
+        <option value={0}>None</option>
+        <option value={1}>Level 1</option>
+        <option value={2}>Level 2</option>
+        <option value={3}>Level 3</option>
+      </select>
       <br />
     </>
   );

--- a/src/content/colosseum/js/ColosseumRegion.ts
+++ b/src/content/colosseum/js/ColosseumRegion.ts
@@ -51,6 +51,13 @@ class SceneCoordinateLabel extends Entity {
   create3dModel() { return CanvasSpriteModel.forRenderable(this); }
 }
 
+class MyopicPlayer extends Player {
+  override get attackRange() {
+    const { myopiaLevel } = colosseumSettings.getSnapshot();
+    return Math.max(1, (this.equipment.weapon?.attackRange ?? 1) - 2 * myopiaLevel);
+  }
+}
+
 export class ColosseumRegion extends Region {
   constructor(loadouts: Loadout[] = [colosseumLoadout]) {
     super(loadouts);
@@ -104,7 +111,7 @@ export class ColosseumRegion extends Region {
 
   initialiseRegion() {
     // create player
-    const player = new Player(this, {
+    const player = new MyopicPlayer(this, {
       x: 27,
       y: 29,
     });

--- a/src/content/colosseum/js/ColosseumSettings.ts
+++ b/src/content/colosseum/js/ColosseumSettings.ts
@@ -8,6 +8,7 @@ import {
 
 export type ColosseumSettingsState = {
   forceDoubleSouth: boolean;
+  myopiaLevel: number;
   npcsAggressive: boolean;
   waveNumber: number;
   showSolarFlareTiles: boolean;
@@ -22,6 +23,7 @@ export type ColosseumSettingsState = {
 const STORAGE_KEY = "colosseum-trainer:settings";
 const defaults: ColosseumSettingsState = {
   forceDoubleSouth: false,
+  myopiaLevel: 0,
   npcsAggressive: true,
   waveNumber: 10,
   showSolarFlareTiles: false,
@@ -53,6 +55,7 @@ const storage: SettingsStorage<ColosseumSettingsState> = {
     );
     const migrated = {
       forceDoubleSouth: false,
+      myopiaLevel: 0,
       npcsAggressive: true,
       waveNumber: 10,
       showSolarFlareTiles: window.localStorage.getItem("showSolarFlareTiles") === "true",


### PR DESCRIPTION
just a wrapper around Player to override the attack range with the current level of myopia. for my own selfish reasons (using a nox-hally with range 1 when myopia is enabled).